### PR TITLE
feat: add permissions api to listen for camera permission state changes

### DIFF
--- a/public/js/user.js
+++ b/public/js/user.js
@@ -1,6 +1,3 @@
-const SEEN_ONCE_QUERY = 'timetoshine=1';
-const has_seen_once = location.search.indexOf(SEEN_ONCE_QUERY) !== -1;
-
 // Connection status elements
 const startCameraBtn = document.getElementById('start-camera-btn'); //to start the camera and flashlight
 const stopCameraBtn = document.getElementById('stop-camera-btn'); //to stop the camera and flashlight
@@ -10,10 +7,8 @@ const infoText = document.getElementById('info-text'); //to indicate when the sh
 // Initialize Socket.IO
 const socket = io();
 
-if (has_seen_once) {
-  // OR: "Tap again, Yours truly, Android Police."
-  startCameraBtn.innerText = "Tap to Begin";
-}
+let requesting_camera = false;
+let listening_to_camera_permissions = false;
 
 //Variables
 let currentStream = null;
@@ -38,13 +33,13 @@ socket.on('start-light-show', (dataPoint) => {
         //if we have access to the flashlight, adjust the brightness otherwise just use the border color
         if (flashlight && currentTrack) {
             //adjust the brightness of the flashlight to the brightness value
-            if (brightness == 0) {
+            if (brightness === 0) {
                 currentTrack.applyConstraints({
                     advanced: [{ torch: false }]
                 });
-            } else if (brightness == 1) {
+            } else if (brightness === 1) {
                 currentTrack.applyConstraints({
-                    advanced: [{torch: true}]
+                    advanced: [{ torch: true }]
                 });
             }
         } else {
@@ -90,38 +85,71 @@ socket.on('pause-light-show', () => {
 
 // ===================================================================================================================================================
 // Camera and flashlight handling
-async function startCameraAndFlashlight() {
-    participatingInLightShow = true;
+
+// Iterates available devices to exhaustion until finding a match.
+async function _startCamera(cameras) {
+    const camera = cameras.pop()
+    console.log("trying", camera)
+    if (!camera) throw new Error("No cameras left.")
+    const stream = await navigator.mediaDevices.getUserMedia({
+        video: {
+            deviceId: camera.deviceId,
+        },
+    })
+    if (!stream) throw new Error("No Stream")
+    const track = stream.getVideoTracks()[0]
+    if (!track) throw new Error("No Track")
+    const has_torch = track.getCapabilities().torch
+    if (!has_torch) {
+        track.stop()
+        return await flashlightHandler._startCamera(cameras)
+    }
+    return {stream, track}
+}
+
+// Listens to camera permission changes - and attempts to connect
+function _listenToCameraPermissionChanges(callbackAsync) {
+    if (listening_to_camera_permissions) return;
+    listening_to_camera_permissions = true;
+
+    // Listen.
+    navigator.permissions
+        .query({ name: "camera" })
+        .then((permissionStatus) => {
+            console.log(`camera permission state is ${permissionStatus.state}`)
+            permissionStatus.onchange = () => {
+                console.log(
+                    `camera permission state has changed to ${permissionStatus.state === "granted"}`,
+                )
+                if (permissionStatus.state.toString() === "granted") {
+                    // Give the device half a second - before we request another track.
+                    setTimeout(() => {
+                    // Abort if the track was good.
+                    if (flashlightHandler.track) return
+                    if (requesting_camera) {
+                        callbackAsync?.call(2).catch((ex) => {
+                        console.error("Failed with permission - no torch", ex);
+                        });
+                    }
+                    }, 500)
+                }
+            }
+        })
+}
+
+
+async function _startCameraAndFlashlight(attemptCount) {
     try {
         const devices = await navigator.mediaDevices.enumerateDevices();
         const cameras = devices.filter((device) => device.kind === 'videoinput');
-        if (cameras.length === 0) throw new Error("CRAP");
-        // Request camera and flashlight permissions
-        const stream = await navigator.mediaDevices.getUserMedia({
-            video: {
-                deviceId: cameras.pop()?.deviceId,
-            }
-        });
+
+        const success = await _startCamera(cameras);
+
+        if (!success || !success.stream || !success.track) throw new Error("No dice");
+
         // Store the stream and track for later use
-        currentStream = stream;
-        currentTrack = stream.getVideoTracks()[0];
-
-        const has_torch = currentTrack?.getCapabilities().torch;
-
-        if (!has_torch) {
-
-          if (!has_seen_once) {
-            // CUT - again - with the lights!
-            const separator = location.href.indexOf('?') === -1 ? '?' : '&';
-            location.href = `${location.href}${separator}${SEEN_ONCE_QUERY}`;
-            return;
-          } else {
-            // This just ain't gonna work
-            // TODO: - something different.
-            updateUI('flashlight-failed');
-            startCameraBtn.innerText = 'Join Light Show';
-          }
-        }
+        currentStream = success.stream;
+        currentTrack = success.track;
 
         // Set up camera feed
         cameraFeed.srcObject = stream;
@@ -129,14 +157,16 @@ async function startCameraAndFlashlight() {
         // Try to enable flashlight
         try {
             await currentTrack.applyConstraints({
-                 advanced: [{torch: false}]
+                advanced: [{ torch: false }]
             });
             socket.emit('flashlight-connect');
             updateUI('success');
-
+            requesting_camera = false;
         } catch (error) {
             console.warn('Flashlight not found:', error);
-            updateUI('flashlight-failed');
+            if (attemptCount !== 1) {
+                updateUI('flashlight-failed');
+            }
         }
 
     } catch (error) {
@@ -145,8 +175,23 @@ async function startCameraAndFlashlight() {
         } else {
             console.warn('Error accessing camera:', error);
         }
-        updateUI('camera-failed');
+        if (attemptCount !== 1) {
+            updateUI('camera-failed');
+        }
     }
+
+    if (attemptCount !== 1) {
+        requesting_camera = false;
+    }
+}
+
+async function startCameraAndFlashlight() {
+    if (requesting_camera) return;
+    requesting_camera = true;
+
+    participatingInLightShow = true;
+    _listenToCameraPermissionChanges(_startCameraAndFlashlight)
+    await _startCameraAndFlashlight(1);
 }
 
 function stopCameraAndFlashlight() {
@@ -176,12 +221,12 @@ function stopCameraAndFlashlight() {
 // UI update
 function updateUI(state) {
     
-    if (state == 'success') {
+    if (state === 'success') {
         flashlight = true;
         infoText.innerHTML = '';
         startCameraBtn.style.display = 'none';
         stopCameraBtn.style.display = 'inline-block';
-    } else if (state == 'camera-failed' || state == 'flashlight-failed') {
+    } else if (state === 'camera-failed' || state === 'flashlight-failed') {
         flashlight = false;
         infoText.innerHTML = 'Failed to connect the flashlight, please try again.';
         startCameraBtn.style.display = 'inline-block';


### PR DESCRIPTION
when first requesting devices - without permission the browser doesnt share non-standard capabilities.

After permissions are granted - torch capability can be tested.